### PR TITLE
Updating <<-EOS.undent to <<~EOS

### DIFF
--- a/Formula/cachalot.rb
+++ b/Formula/cachalot.rb
@@ -14,7 +14,7 @@ class Cachalot < Formula
     prefix.install "cli"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Run `amazeeio-cachalot create` to create the VM, then `amazeeio-cachalot up` to bring up the VM and services.
     EOS
   end


### PR DESCRIPTION

<img width="994" alt="screen shot 2018-04-23 at 10 08 15 am" src="https://user-images.githubusercontent.com/29987184/39143053-dfd504ae-46e9-11e8-9f77-52f66c124e2d.png">
I received an error of Calling <<-EOS.undent is disabled after running brew install cachalot. The error suggested using <<~EOS instead and making a PR for the issue. After a little research this seems to be a known issue and fix. Attached are a couple links I found useful. I hope this helps!

Thanks!

https://github.com/Homebrew/homebrew-php/issues/4727
https://anti-pattern.com/strip-leading-whitespace-from-heredocs-in-ruby